### PR TITLE
feature/tls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,17 @@ templ:
 tailwindcss:
 	$(MAKE) build/css/stylesheet.css
 
+# Generates self-signed certificates for build if none exist already. This presumes Go is installed in the location suggested by the official Go docs.
+# If certificates need to be renewed for testing, simply delete the files.
+# In production, use proper certificates signed by an authority rather than the ones generated here.
 build/tls/cert.pem build/tls/key.pem: | build/bin/server
 	mkdir -p $$(dirname $@)	
 	cd build/tls/ && go run /usr/local/go/src/crypto/tls/generate_cert.go --rsa-bits=2048 --host=localhost
 
-# Generates Tailwindcss if html files have been updated or the input.css file was updated.
+# Generates Tailwindcss if Templ HTML has been updated, if the the input.css file has been updated, or if the javascript files have been updated.
+# Any of these three files could result in new TailwindCSS utility classes being added.
+# Removes old stylesheet.css in the case that the prerequistes were updated but no new utility classes were called resulting in the stylesheet.css being skipped by the
+# TailwindCSS cli tool
 build/css/stylesheet.css : $(buildtempl) src/css/input.css $(buildjs)
 	rm -f build/css/stylesheet.css
 	npx @tailwindcss/cli -m  -i src/css/input.css -o build/css/stylesheet.css 
@@ -42,7 +48,6 @@ $(buildtempl):src/webserver/%_templ.go:src/webserver/%.templ
 build/bin/server : $(go) $(buildtempl)
 	echo $(buildhtml)
 	go build -C src/webserver/ -o ../../build/bin/server
-
 
 # Copy any updated sql files
 $(buildsql):build/sql/% :src/sql/%

--- a/src/webserver/main.go
+++ b/src/webserver/main.go
@@ -198,6 +198,7 @@ func main() {
 		WriteTimeout: 5 * time.Second,
 	}
 
+	// Able to run with or without TLS encryption, depending if the certificate files can be found.
 	var runerr error
 	if *certpath != "" && *keypath != "" {
 		fmt.Println("Running with tls certificate...")

--- a/src/webserver/main.go
+++ b/src/webserver/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/a-h/templ"
 )
@@ -186,5 +187,19 @@ func main() {
 	mux.Handle("GET /css/", http.StripPrefix("/css", fileServer))
 	mux.Handle("GET /fonts/", http.StripPrefix("/fonts", fontServer))
 	mux.Handle("GET /js/", http.StripPrefix("/js", jsServer))
-	http.ListenAndServe(fmt.Sprintf(":%s", port), mux)
+	//http.ListenAndServe(fmt.Sprintf(":%s", port), mux)
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%s", port),
+		Handler:      mux,
+		IdleTimeout:  5 * time.Second,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	err := server.ListenAndServe()
+
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 }


### PR DESCRIPTION
- Now using http.Server instead of just http.ListenAndServe()
- Added self-signed certification creation step in build file. Improved makefile build/css/stylesheet.css step be always cleaning out old file so that tailwind always builds a clean css if any of the prerequistes are updates. This fixes bug that always caused this step to run but the css was not updated, resulting tailwindcss/cli not updating modification date on stylesheet.css.
- Added comments to Makefile and main.go that detail additions made in previous couple commits.
